### PR TITLE
Fix: broken link between articles on Lambda Layers

### DIFF
--- a/posts/lambda-layers.md
+++ b/posts/lambda-layers.md
@@ -64,7 +64,7 @@ Lambda 同士で共通の処理を切り出せる [Lambda Layers](https://docs.a
 
 外部モジュールを使用するとき、各デプロイパッケージ内の requirements.txt に書くのではなくインポート用だけのレイヤーを作るといいよ、という記事を書きました。これは AWS も推奨しているソリューションのようです。
 
-[https://mirumi.me/tech/153/]
+[/lambda-layers-import]
 
 ## （さらに追記）
 


### PR DESCRIPTION
通りすがりのものですが、記事間のリンクが切れているようですので、修正してみました。
もしよければ取り込んでいただけると幸いです。

- リンク元：[『Lambda レイヤーを実際のプロジェクトで使ってみて不便に感じたこと』](https://mirumi.tech/lambda-layers/)
- リンク先：[『Lambda(SAM) の外部モジュールインストールには Layer の requirements を使おう』](https://mirumi.tech/lambda-layers-import/)

よろしくお願いいたします。